### PR TITLE
[wip] Simplify idle extension

### DIFF
--- a/examples/idle.rs
+++ b/examples/idle.rs
@@ -34,17 +34,7 @@ fn fetch_messages_and_idle(server: &str, login: &str, password: &str) -> imap::e
     println!("got {} messages", messages.len());
     {
         loop {
-            let res = match imap_session.idle() {
-                Ok(mut idle) => {
-                    &idle.set_keepalive(Duration::from_secs(20));
-                    println!("entering idle wait_keepalive");
-                    idle.wait_keepalive()
-                }
-                Err(err) => {
-                    return Err(imap::error::Error::Bad(err.to_string()));
-                }
-            };
-            match res {
+            match imap_session.idle_and_wait(Duration::from_secs(23 * 60)) {
                 Ok(true) => {
                     println!("wait_keepalive returned data, idle-finished");
                     break;

--- a/src/client.rs
+++ b/src/client.rs
@@ -9,6 +9,7 @@ use std::net::{TcpStream, ToSocketAddrs};
 use std::ops::{Deref, DerefMut};
 use std::str;
 use std::sync::mpsc;
+use std::time::Duration;
 
 use super::authenticator::Authenticator;
 use super::error::{Error, ParseError, Result, ValidateError};
@@ -985,8 +986,9 @@ impl<T: Read + Write> Session<T> {
     /// command, as specified in the base IMAP specification.
     ///
     /// See [`extensions::idle::Handle`] for details.
-    pub fn idle(&mut self) -> Result<extensions::idle::Handle<'_, T>> {
-        extensions::idle::Handle::make(self)
+    pub fn idle_and_wait(&mut self, keepalive_interval: Duration) -> Result<bool> {
+        let handle = extensions::idle::Handle::make(self)?;
+        handle.idle_and_wait(keepalive_interval)
     }
 
     /// The [`APPEND` command](https://tools.ietf.org/html/rfc3501#section-6.3.11) appends

--- a/src/client.rs
+++ b/src/client.rs
@@ -11,6 +11,8 @@ use std::str;
 use std::sync::mpsc;
 use std::time::Duration;
 
+use crate::extensions::idle::SetReadTimeout;
+
 use super::authenticator::Authenticator;
 use super::error::{Error, ParseError, Result, ValidateError};
 use super::extensions;
@@ -986,8 +988,11 @@ impl<T: Read + Write> Session<T> {
     /// command, as specified in the base IMAP specification.
     ///
     /// See [`extensions::idle::Handle`] for details.
-    pub fn idle_and_wait(&mut self, keepalive_interval: Duration) -> Result<bool> {
-        let handle = extensions::idle::Handle::make(self)?;
+    pub fn idle_and_wait(&mut self, keepalive_interval: Duration) -> Result<bool> 
+    where
+        T: SetReadTimeout + Read + Write,
+    {
+        let mut handle = extensions::idle::Handle::make(self)?;
         handle.idle_and_wait(keepalive_interval)
     }
 

--- a/src/extensions/idle.rs
+++ b/src/extensions/idle.rs
@@ -49,7 +49,7 @@ pub trait SetReadTimeout {
 
 impl<'a, T: Read + Write + 'a> Handle<'a, T> {
     pub(crate) fn make(session: &'a mut Session<T>) -> Result<Self> {
-        let mut handle = Handle {
+        let handle = Handle {
             session,
             initialized: false,
         };
@@ -98,7 +98,7 @@ impl<'a, T: SetReadTimeout + Read + Write + 'a> Handle<'a, T> {
     /// a typical Duration many mail apps use is 23*60=1380 seconds although
     /// RFC 2177 recommends 29 minutes.
     ///
-    pub fn idle_and_wait(self, keepalive_interval: Duration) -> Result<bool> {
+    pub fn idle_and_wait(&mut self, keepalive_interval: Duration) -> Result<bool> {
         // The server MAY consider a client inactive if it has an IDLE command
         // running, and if such a server has an inactivity timeout it MAY log
         // the client off implicitly at the end of its timeout period.  Because


### PR DESCRIPTION
The basic idea of this PR is towards the extension only offering a single idle_and_wait() call that does all initializing/finalizing of the idle call.  I suggest to consider the idle extension to only be defined whe SetReadTimeout trait is present -- but not sure how to express this in Rust.  From reviewing idle_and_wait() one should be able to deduce that it is correct and well-behaving function. Exposing init/finalize/wait_keepalive as three separate APIs to the extension user is unneeded flexibility. 

This almost works but maybe there is a deeper problem about SetReadTimeout trait and its relation/effect in idle.rs.  
